### PR TITLE
Prevent webhook from blocking controller pod creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,20 @@ install: manifests
 uninstall: manifests
 	kustomize build config/crd | kubectl delete -f -
 
+delete: manifests
+	cd config/manager && kustomize edit set image controller=${IMG}
+	kustomize build config/default | kubectl delete -f -
+
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-deploy: manifests
+deploy: manifests cert-manager
 	cd config/manager && kustomize edit set image controller=${IMG}
 	kustomize build config/default | kubectl apply -f -
+
+cert-manager:
+    kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
+	kubectl rollout status deployment cert-manager-webhook -n cert-manager
+	kubectl rollout status deployment cert-manager -n cert-manager
+	kubectl rollout status deployment cert-manager-cainjector -n cert-manager
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,12 +16,12 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:
@@ -30,7 +30,7 @@ patchesStrategicMerge:
   # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - manager_webhook_patch.yaml
 
@@ -38,6 +38,11 @@ patchesStrategicMerge:
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
 - webhookcainjection_patch.yaml
+
+# [WEBHOOK] To add namespaceselector to weebhook.
+# so that webhook won't check namespaces with specific labels
+# avoid blocking controller coming up
+- webhook_namespaceselector_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/config/default/webhook_namespaceselector_patch.yaml
+++ b/config/default/webhook_namespaceselector_patch.yaml
@@ -1,0 +1,13 @@
+# This patch add namespace selector to admission webhook config and
+# resources under namespace with this label won't trigger this webhook
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- name: mimg.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: harbor-day2-webhook-configuration
+      operator: NotIn
+      values: ["disabled"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    harbor-day2-webhook-configuration: disabled
   name: system
 ---
 apiVersion: apps/v1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    ## this is for avoiding being checked by webhook
     harbor-day2-webhook-configuration: disabled
   name: system
 ---


### PR DESCRIPTION
Resolve https://github.com/szlabs/harbor-automation-4k8s/issues/14

Add label `harbor-day2-webhook-configuration: disabled` to namespace.
Add check inside webhook to avoid check on namespace with labels `harbor-day2-webhook-configuration: disabled`