### PR TITLE
Add logic to validate project and robot information in ns controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ The diagram below shows the overall design of this project:
 * A cluster scoped Kubernetes CR named `HarborServerConfiguration` is designed to keep the Harbor server access info by providing the access
 host and access key & secret (key and secret should be wrapped into a kubernetes secret) for future referring.
 * To enable the image pull secret injection in a Kubernetes namespace:
-  - add the annotation `goharbor.io/secret-issuer:[harborserverconfiguration_cr_name]` to the namespace. `harborserverconfiguration_cr_name` 
+  - add the annotation `goharbor.io/secret-issuer:[harborserverconfiguration_cr_name]` to the namespace. `harborserverconfiguration_cr_name`
   is the name of the CR `HarborServerConfiguration` that includes the Harbor server info.
-  - add the annotation `goharbor.io/service-account:[service_account_name]` to the namespace. `service_account_name` is the 
+  - add the annotation `goharbor.io/service-account:[service_account_name]` to the namespace. `service_account_name` is the
   name of the Kubernetes service account that you want to use to bind the image pulling secret later.
 * When the namespace is created, the operator will check the related annotations set above. If they're set, then:
   - ensures a corresponding harbor project exists (or creates one if none exists) at the Harbor referred by
@@ -102,12 +102,16 @@ kind: HarborServerConfiguration
 metadata:
   name: harborserverconfiguration-sample
 spec:
-  serverURL: 192.168.1.11
+  default: true ## whether it will be default global hsc
+  serverURL: 10.168.167.189
   accessCredential:
     namespace: kube-system
     accessSecretRef: mysecret
   version: 2.1.0
   inSecure: true
+  rules: ## rules to define to rewrite image path
+  - registryRegex: "^docker.io$"
+    project: myHarborProject
 ```
 
 Create it:

--- a/api/v1alpha1/harborserverconfiguration_types.go
+++ b/api/v1alpha1/harborserverconfiguration_types.go
@@ -39,7 +39,8 @@ type HarborServerConfigurationSpec struct {
 	// +kubebuilder:validation:Optional
 	InSecure bool `json:"inSecure,omitempty"`
 
-	// Default indicates the harbor configuration manages namespaces that omit the goharbor.io/secret-issuer annotation.
+	// Default indicates the harbor configuration manages namespaces.
+	// Value in goharbor.io/secret-issuer annotation will be considered with high priority.
 	// At most, one HarborServerConfiguration can be the default, multiple defaults will be rejected.
 	// +kubebuilder:validation:Required
 	Default bool `json:"default"`

--- a/api/v1alpha1/pullsecretbinding_types.go
+++ b/api/v1alpha1/pullsecretbinding_types.go
@@ -28,13 +28,13 @@ type PullSecretBindingSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Robot points to the robot account used for secret binding
+	// RobotID points to the robot account id used for secret binding
 	// +kubebuilder:validation:Required
-	Robot string `json:"robot"`
+	RobotID string `json:"robotId"`
 
-	// Project points to the project associated with the secret binding
+	// ProjectID points to the project associated with the secret binding
 	// +kubebuilder:validation:Required
-	Project string `json:"project"`
+	ProjectID string `json:"projectId"`
 
 	// Indicate which harbor server configuration is referred
 	HarborServerConfig string `json:"harborServerConfig"`

--- a/api/v1alpha1/pullsecretbinding_types.go
+++ b/api/v1alpha1/pullsecretbinding_types.go
@@ -28,6 +28,14 @@ type PullSecretBindingSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// Robot points to the robot account used for secret binding
+	// +kubebuilder:validation:Required
+	Robot string `json:"robot"`
+
+	// Project points to the project associated with the secret binding
+	// +kubebuilder:validation:Required
+	Project string `json:"project"`
+
 	// Indicate which harbor server configuration is referred
 	HarborServerConfig string `json:"harborServerConfig"`
 

--- a/config/crd/bases/goharbor.goharbor.io_harborserverconfigurations.yaml
+++ b/config/crd/bases/goharbor.goharbor.io_harborserverconfigurations.yaml
@@ -64,7 +64,7 @@ spec:
                 - namespace
                 type: object
               default:
-                description: Default indicates the harbor configuration manages namespaces that omit the goharbor.io/secret-issuer annotation. At most, one HarborServerConfiguration can be the default, multiple defaults will be rejected.
+                description: Default indicates the harbor configuration manages namespaces. Value in goharbor.io/secret-issuer annotation will be considered with high priority. At most, one HarborServerConfiguration can be the default, multiple defaults will be rejected.
                 type: boolean
               inSecure:
                 description: Indicate if the Harbor server is an insecure registry

--- a/config/crd/bases/goharbor.goharbor.io_pullsecretbindings.yaml
+++ b/config/crd/bases/goharbor.goharbor.io_pullsecretbindings.yaml
@@ -52,19 +52,19 @@ spec:
               harborServerConfig:
                 description: Indicate which harbor server configuration is referred
                 type: string
-              project:
-                description: Project points to the project associated with the secret binding
+              projectId:
+                description: ProjectID points to the project associated with the secret binding
                 type: string
-              robot:
-                description: Robot points to the robot account used for secret binding
+              robotId:
+                description: RobotID points to the robot account id used for secret binding
                 type: string
               serviceAccount:
                 description: Indicate which service account binds the pull secret
                 type: string
             required:
             - harborServerConfig
-            - project
-            - robot
+            - projectId
+            - robotId
             - serviceAccount
             type: object
           status:

--- a/config/crd/bases/goharbor.goharbor.io_pullsecretbindings.yaml
+++ b/config/crd/bases/goharbor.goharbor.io_pullsecretbindings.yaml
@@ -52,11 +52,19 @@ spec:
               harborServerConfig:
                 description: Indicate which harbor server configuration is referred
                 type: string
+              project:
+                description: Project points to the project associated with the secret binding
+                type: string
+              robot:
+                description: Robot points to the robot account used for secret binding
+                type: string
               serviceAccount:
                 description: Indicate which service account binds the pull secret
                 type: string
             required:
             - harborServerConfig
+            - project
+            - robot
             - serviceAccount
             type: object
           status:

--- a/controllers/namespace_controller.go
+++ b/controllers/namespace_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 
+	harborClient "github.com/szlabs/harbor-automation-4k8s/pkg/controllers/harbor"
 	"github.com/szlabs/harbor-automation-4k8s/pkg/utils"
 
 	"github.com/go-logr/logr"
@@ -85,21 +86,14 @@ func (r *NamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	// If auto-wire is set
-	harborCfg, yes := ns.Annotations[annotationIssuer]
-	if !yes {
-		// If the annotation is removed and binding CRs are existing
-		if len(bindings.Items) > 0 {
-			for _, bd := range bindings.Items {
-				// Remove all the existing bindings as issuer is removed
-				if err := r.Client.Delete(ctx, &bd, &client.DeleteOptions{}); err != nil {
-					// Retry next time
-					return ctrl.Result{}, fmt.Errorf("remove binding %s error: %w", bd.Name, err)
-				}
-			}
-		}
+	harborCfg, err := r.findDefaultHarborCfg(ctx, log, ns)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error finding harborCfg: %w", err)
+	}
 
-		// Match desired status, no issuers and then no bindings
-		// Reconcile is completed
+	if harborCfg == nil {
+		log.Info("no default hsc for this namespace")
+		r.removeStalePSB(ctx, bindings)
 		return ctrl.Result{}, nil
 	}
 
@@ -112,7 +106,7 @@ func (r *NamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		sa := &corev1.ServiceAccount{}
 		saNamespacedName := types.NamespacedName{
 			Namespace: ns.Name,
-			Name:      saName,
+			Name:      setSa,
 		}
 		if err := r.Client.Get(ctx, saNamespacedName, sa); err != nil {
 			if apierr.IsNotFound(err) {
@@ -125,8 +119,9 @@ func (r *NamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	// Find PSB
 	for _, bd := range bindings.Items {
-		if bd.Spec.HarborServerConfig == harborCfg && bd.Spec.ServiceAccount == saName {
+		if bd.Spec.HarborServerConfig == harborCfg.Name && bd.Spec.ServiceAccount == saName {
 			// Found it and reconcile is done
+			log.Info("psb exist for this namespace")
 			return ctrl.Result{}, nil
 		}
 	}
@@ -138,44 +133,48 @@ func (r *NamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// Skip PSB creation if project and robot don't match
 	if projExist != robotExist {
 		// TODO: refine logging
-		log.Error(fmt.Errorf("project: %s, robot: %s", proj, robot), "Harbor annotation for project and robot doesn't match")
+		log.Error(fmt.Errorf("project: %s, robot: %s", proj, robot), "Harbor annotation for project and robot have to be set at the same time")
 		return ctrl.Result{}, nil
 	}
 
+	// Create harbor client
+	harborV2, harborLegacy, err := harborClient.CreateHarborClients(ctx, r.Client, harborCfg)
+	if err != nil {
+		log.Error(err, "failed to create harbor client")
+		return ctrl.Result{}, nil
+	}
+	r.HarborV2 = harborV2
+	r.Harbor = harborLegacy
+
 	// Validate project and robot if both non-empty
 	if projExist {
+		log.Info("validate project and robot account")
 		err := r.validateProjectRobot(proj, robot)
 		if err != nil {
 			log.Error(err, "Harbor annotation for project and robot invalid", "project", proj, "robot", robot)
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, fmt.Errorf("project and robot are invalid: %w", err)
 		}
 	}
 
 	// Automatically generate project and robot account based on namespace name
+	var projID, robotID string
 	if !projExist {
+		// TODO: should be more structure name since many clusters might share the same Harbor instance
 		proj = utils.RandomName(ns.Name)
-		robotID, err := r.createProjectRobot(proj)
+		projID, robotID, err = r.createProjectAndRobot(proj)
 		if err != nil {
 			log.Error(err, "Failed creating project and robot", "project", proj, "robot", robot)
 			return ctrl.Result{}, nil
 		}
-		robot = robotID
 	}
 
 	// PSB doesn't exist, create one
-	defaultBinding := r.getNewBindingCR(ns.Name, harborCfg, saName)
-	if err := controllerutil.SetControllerReference(ns, defaultBinding, r.Scheme); err != nil {
-		return ctrl.Result{}, fmt.Errorf("set ctrl reference error: %w", err)
+	log.Info("creating pull secret binding")
+	psb, err := r.createPullSecretBinding(ctx, ns, harborCfg.Name, saName, robotID, projID)
+	if err != nil {
+		return ctrl.Result{}, nil
 	}
-
-	defaultBinding.Spec.Robot = robot
-	defaultBinding.Spec.Project = proj
-
-	if err := r.Client.Create(ctx, defaultBinding, &client.CreateOptions{}); err != nil {
-		return ctrl.Result{}, fmt.Errorf("create binding CR error: %w", err)
-	}
-
-	log.Info("create pull secret binding", "name", defaultBinding.Name)
+	log.Info("created pull secret binding", "name", psb.Name)
 
 	return ctrl.Result{}, nil
 }
@@ -199,27 +198,95 @@ func (r *NamespaceReconciler) getNewBindingCR(ns string, harborCfg string, sa st
 	}
 }
 
-func (r *NamespaceReconciler) validateProjectRobot(proj, robot string) error {
+func (r *NamespaceReconciler) validateProjectRobot(projName, robot string) error {
 	robotID, err := strconv.ParseInt(robot, 10, 64)
-	if err == nil {
-		return err
-	}
-	projID, err := r.HarborV2.EnsureProject(proj)
 	if err != nil {
 		return err
 	}
-	_, err = r.Harbor.GetRobotAccount(projID, robotID)
+
+	proj, err := r.HarborV2.GetProject(projName)
+	if err != nil {
+		return err
+	}
+	_, err = r.Harbor.GetRobotAccount(int64(proj.ProjectID), robotID)
 	return err
 }
 
-func (r *NamespaceReconciler) createProjectRobot(proj string) (string, error) {
+func (r *NamespaceReconciler) createProjectAndRobot(proj string) (string, string, error) {
 	projID, err := r.HarborV2.EnsureProject(proj)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
+
 	robot, err := r.Harbor.CreateRobotAccount(projID)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return fmt.Sprintf("%d", robot.ID), nil
+
+	return fmt.Sprintf("%d", projID), fmt.Sprintf("%d", robot.ID), nil
+}
+
+func (r *NamespaceReconciler) findDefaultHarborCfg(ctx context.Context, log logr.Logger, ns *corev1.Namespace) (*goharborv1alpha1.HarborServerConfiguration, error) {
+	// check annotation first
+	harborCfg, yes := ns.Annotations[annotationIssuer]
+	if yes && harborCfg != "" {
+		hsc := &goharborv1alpha1.HarborServerConfiguration{}
+		err := r.Client.Get(ctx, types.NamespacedName{Name: harborCfg}, hsc)
+		if err != nil {
+			if apierr.IsNotFound(err) {
+				log.Info("hsc specified in annotation doesn't exist")
+				return nil, nil
+			}
+
+			return nil, fmt.Errorf("error when finding hsc specified in annotation: %w", err)
+		}
+		return hsc, nil
+	}
+	log.Info("no default hsc found in annotation")
+
+	// then find global default hsc
+	hscs := &goharborv1alpha1.HarborServerConfigurationList{}
+	err := r.Client.List(ctx, hscs)
+	if err != nil {
+		return nil, fmt.Errorf("error listing harborCfg: %w", err)
+	}
+
+	if len(hscs.Items) > 0 {
+		for _, hsc := range hscs.Items {
+			if hsc.Spec.Default {
+				log.Info("found global default hsc: " + hsc.Name)
+				return &hsc, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (r *NamespaceReconciler) removeStalePSB(ctx context.Context, bindings *goharborv1alpha1.PullSecretBindingList) error {
+	if len(bindings.Items) > 0 {
+		for _, bd := range bindings.Items {
+			// Remove all the existing bindings as issuer is removed
+			if err := r.Client.Delete(ctx, &bd, &client.DeleteOptions{}); err != nil {
+				// Retry next time
+				return fmt.Errorf("remove binding %s error: %w", bd.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (r *NamespaceReconciler) createPullSecretBinding(ctx context.Context, ns *corev1.Namespace, harborCfg, saName, robotID, projID string) (*goharborv1alpha1.PullSecretBinding, error) {
+	defaultBinding := r.getNewBindingCR(ns.Name, harborCfg, saName)
+	if err := controllerutil.SetControllerReference(ns, defaultBinding, r.Scheme); err != nil {
+		return nil, fmt.Errorf("set ctrl reference error: %w", err)
+	}
+
+	defaultBinding.Spec.RobotID = robotID
+	defaultBinding.Spec.ProjectID = projID
+
+	if err := r.Client.Create(ctx, defaultBinding, &client.CreateOptions{}); err != nil {
+		return nil, fmt.Errorf("create binding CR error: %w", err)
+	}
+
+	return defaultBinding, nil
 }

--- a/controllers/namespace_controller.go
+++ b/controllers/namespace_controller.go
@@ -168,10 +168,8 @@ func (r *NamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, fmt.Errorf("set ctrl reference error: %w", err)
 	}
 
-	// TODO: add project and robot in PSB spec instead of annotation
-	defaultBinding.Annotations = make(map[string]string)
-	defaultBinding.Annotations[annotationProject] = proj
-	defaultBinding.Annotations[annotationRobot] = robot
+	defaultBinding.Spec.Robot = robot
+	defaultBinding.Spec.Project = proj
 
 	if err := r.Client.Create(ctx, defaultBinding, &client.CreateOptions{}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("create binding CR error: %w", err)

--- a/controllers/pullsecretbinding_controller.go
+++ b/controllers/pullsecretbinding_controller.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -133,7 +132,7 @@ func (r *PullSecretBindingReconciler) Reconcile(req ctrl.Request) (res ctrl.Resu
 		}
 	}()
 
-	projID, robotID := parseIntID(bd.Spec.Project), parseIntID(bd.Spec.Robot)
+	projID, robotID := parseIntID(bd.Spec.ProjectID), parseIntID(bd.Spec.RobotID)
 
 	// Bind robot to service account
 	// TODO: may cause dirty robots at the harbor project side
@@ -329,7 +328,7 @@ func (r *PullSecretBindingReconciler) createRegSec(ctx context.Context, namespac
 			Annotations: map[string]string{
 				annotationSecOwner: defaultOwner,
 			},
-			OwnerReferences: []v1.OwnerReference{{APIVersion: psb.APIVersion, Kind: psb.Kind, Name: psb.Name, UID: psb.UID}},
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: psb.APIVersion, Kind: psb.Kind, Name: psb.Name, UID: psb.UID}},
 		},
 		Type: regSecType,
 		Data: map[string][]byte{

--- a/controllers/pullsecretbinding_controller.go
+++ b/controllers/pullsecretbinding_controller.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -132,57 +133,21 @@ func (r *PullSecretBindingReconciler) Reconcile(req ctrl.Request) (res ctrl.Resu
 		}
 	}()
 
-	// Check linked project info
-	pro, ok := bd.Annotations[annotationProject]
-	if !ok {
-		pro = utils.RandomName(bd.Namespace)
-	}
-
-	// Ensure project
-	proID, err := r.HarborV2.EnsureProject(pro)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("ensure project error: %w", err)
-	}
-
-	if !ok {
-		setAnnotation(bd, annotationProject, pro)
-		if err := r.update(ctx, bd); err != nil {
-			// TODO: If update failed, how should we handle the created project in Harbor side
-			return ctrl.Result{}, fmt.Errorf("update error: %w", err)
-		}
-	}
+	projID, robotID := parseIntID(bd.Spec.Project), parseIntID(bd.Spec.Robot)
 
 	// Bind robot to service account
 	// TODO: may cause dirty robots at the harbor project side
 	// TODO: check secret binding by get secret and service account
-	_, ok = bd.Annotations[annotationRobotSecretRef]
+	_, ok := bd.Annotations[annotationRobotSecretRef]
 	if !ok {
-		// Clear the useless old one if it is existing
-		if idstr, ok := bd.Annotations[annotationRobot]; ok {
-			if rid, err := strconv.ParseInt(idstr, 10, 64); err == nil {
-				if err := r.Harbor.DeleteRobotAccount(proID, rid); err != nil {
-					// Just log
-					r.Log.Error(err, "delete useless old robot", "ID", rid)
-				} else {
-					r.Log.Error(err, "invalid robot ID", "ID", idstr)
-				}
-			}
-		}
-
 		// Need to create a new one as we only have one time to get the robot token
-		robot, err := r.Harbor.CreateRobotAccount(proID)
+		robot, err := r.Harbor.GetRobotAccount(projID, robotID)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("create robot account error: %w", err)
 		}
 
-		// Keep robot info at this moment in case some of the following steps are failed
-		setAnnotation(bd, annotationRobot, fmt.Sprintf("%d", robot.ID))
-		if err := r.update(ctx, bd); err != nil {
-			return ctrl.Result{}, fmt.Errorf("update error: %w", err)
-		}
-
 		// Make registry secret
-		regsec, err := r.createRegSec(ctx, bd.Namespace, server.ServerURL, robot)
+		regsec, err := r.createRegSec(ctx, bd.Namespace, server.ServerURL, robot, bd)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("create registry secret error: %w", err)
 		}
@@ -203,8 +168,6 @@ func (r *PullSecretBindingReconciler) Reconcile(req ctrl.Request) (res ctrl.Resu
 		if err := controllerutil.SetControllerReference(bd, regsec, r.Scheme); err != nil {
 			r.Log.Error(err, "set controller reference", "owner", bd.ObjectMeta, "controlled", regsec.ObjectMeta)
 		}
-
-		setAnnotation(bd, annotationRobot, fmt.Sprintf("%d", robot.ID))
 		setAnnotation(bd, annotationRobotSecretRef, regsec.Name)
 		if err := r.update(ctx, bd); err != nil {
 			return ctrl.Result{}, fmt.Errorf("update error: %w", err)
@@ -347,7 +310,7 @@ func (r *PullSecretBindingReconciler) getServiceAccount(ctx context.Context, ns,
 	return sc, nil
 }
 
-func (r *PullSecretBindingReconciler) createRegSec(ctx context.Context, namespace string, registry string, robot *model.Robot) (*corev1.Secret, error) {
+func (r *PullSecretBindingReconciler) createRegSec(ctx context.Context, namespace string, registry string, robot *model.Robot, psb *goharborv1alpha1.PullSecretBinding) (*corev1.Secret, error) {
 	auths := &secret.Object{
 		Auths: map[string]*secret.Auth{},
 	}
@@ -366,6 +329,7 @@ func (r *PullSecretBindingReconciler) createRegSec(ctx context.Context, namespac
 			Annotations: map[string]string{
 				annotationSecOwner: defaultOwner,
 			},
+			OwnerReferences: []v1.OwnerReference{{APIVersion: psb.APIVersion, Kind: psb.Kind, Name: psb.Name, UID: psb.UID}},
 		},
 		Type: regSecType,
 		Data: map[string][]byte{
@@ -400,4 +364,9 @@ func setAnnotation(obj *goharborv1alpha1.PullSecretBinding, key string, value st
 	}
 
 	obj.Annotations[key] = value
+}
+
+func parseIntID(id string) int64 {
+	intID, _ := strconv.ParseInt(id, 10, 64)
+	return intID
 }

--- a/pkg/controllers/harbor/client.go
+++ b/pkg/controllers/harbor/client.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	goharborv1alpha1 "github.com/szlabs/harbor-automation-4k8s/api/v1alpha1"
+	"github.com/szlabs/harbor-automation-4k8s/pkg/rest/legacy"
+	"github.com/szlabs/harbor-automation-4k8s/pkg/rest/model"
+	v2 "github.com/szlabs/harbor-automation-4k8s/pkg/rest/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CreateHarborClients(ctx context.Context, client client.Client, hsc *goharborv1alpha1.HarborServerConfiguration) (*v2.Client, *legacy.Client, error) {
+	server, err := createHarborServer(ctx, client, hsc)
+	if err != nil {
+		return nil, nil, err
+	}
+	return v2.NewWithServer(server), legacy.NewWithServer(server), nil
+}
+
+func CreateHarborV2Client(ctx context.Context, client client.Client, hsc *goharborv1alpha1.HarborServerConfiguration) (*v2.Client, error) {
+	server, err := createHarborServer(ctx, client, hsc)
+	if err != nil {
+		return nil, err
+	}
+	return v2.NewWithServer(server), nil
+}
+
+func CreateHarborLegacyClient(ctx context.Context, client client.Client, hsc *goharborv1alpha1.HarborServerConfiguration) (*legacy.Client, error) {
+	server, err := createHarborServer(ctx, client, hsc)
+	if err != nil {
+		return nil, err
+	}
+	return legacy.NewWithServer(server), nil
+}
+
+// Check if the server configuration is valid.
+// That is checking if the admin password secret object is valid.
+func createHarborServer(ctx context.Context, client client.Client, hsc *goharborv1alpha1.HarborServerConfiguration) (*model.HarborServer, error) {
+	// contruct accessCreds from Secret
+
+	secretNSedName := types.NamespacedName{
+		Namespace: hsc.Spec.AccessCredential.Namespace,
+		Name:      hsc.Spec.AccessCredential.AccessSecretRef,
+	}
+	cred, err := createAccessCredsFromSecret(ctx, client, secretNSedName)
+	if err != nil {
+		return nil, err
+	}
+	// put server config into client
+	return model.NewHarborServer(hsc.Spec.ServerURL, cred, hsc.Spec.InSecure), nil
+
+}
+
+func createAccessCredsFromSecret(ctx context.Context, client client.Client, secretNSedName types.NamespacedName) (*model.AccessCred, error) {
+	accessSecret := &corev1.Secret{}
+	if err := client.Get(ctx, secretNSedName, accessSecret); err != nil {
+		// No matter what errors (including not found) occurred, the server configuration is invalid
+		return nil, fmt.Errorf("get access secret error: %w", err)
+	}
+
+	// convert secrets to AccessCred
+	cred := &model.AccessCred{}
+	if err := cred.FillIn(accessSecret); err != nil {
+		return nil, fmt.Errorf("fill in secret error: %w", err)
+	}
+
+	return cred, nil
+}


### PR DESCRIPTION
As the first step moving project & robot validation logic from PSB ctrl to ns controller, duplicating the logic into ns controller.